### PR TITLE
removes players being forced to shit_piss.dm

### DIFF
--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -74,9 +74,9 @@
 		if(species.death_sound)
 			playsound(loc, species.death_sound, 80, 1, 1)
 		spawn(50)
-			if(bowels >= 30)
+			if(bowels >= 30000) //nonmodular bearhammer edit- removes shitting and pissing on death. i feel like a butcher, but what am I to do? temporary solution as i focus on more important stuff.
 				handle_shit()
-			if(bladder >= 30)
+			if(bladder >= 30000) //nonmodular bearhammer edit- removes shitting and pissing on death. i feel like a butcher, but what am I to do? temporary solution as i focus on more important stuff.
 				handle_piss()
 	unlock_achievement(new/datum/achievement/dead())
 	sound_to(src, sound(null, repeat = 1, wait = 0, volume = 70, channel = 4))

--- a/code/modules/mob/shit_piss.dm
+++ b/code/modules/mob/shit_piss.dm
@@ -173,6 +173,7 @@
 		bladder = 0
 		bowels = 0
 
+/* //START NONMODULAR BEARHAMMER EDIT- removes forced shitting/pissing. temporary solution while i work on more important stuff
 	if(bowels >= 250)
 		switch(bowels)
 			if(250 to 400)
@@ -222,6 +223,7 @@
 					bladder += 35
 			if(550 to INFINITY)
 				handle_piss()
+*/ // END NONMODULAR BEARHAMMER EDIT
 
 //Shitting
 /mob/living/carbon/human/proc/handle_shit()


### PR DESCRIPTION
As the above- comments out some code in shit_piss.dm that caused you to piss/poop, and changes a var number in death.dm that handled shitting after-death. Does not touch the ability to piss or poop in itself- will handle that later.